### PR TITLE
Rejuvenate log levels using another set of settings

### DIFF
--- a/IRCT-API/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/controller/ProcessController.java
+++ b/IRCT-API/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/controller/ProcessController.java
@@ -57,7 +57,7 @@ public class ProcessController implements Serializable{
 		} else {
 			entityManager.merge(this.process);
 		}
-		log.info("Process " + this.process.getId() + " saved");
+		log.finest("Process " + this.process.getId() + " saved");
 
 	}
 
@@ -76,7 +76,7 @@ public class ProcessController implements Serializable{
 		if (this.process == null) {
 			throw new ProcessException("No process to load.");
 		}
-		log.info("Query " + this.process.getId() + " loaded");
+		log.finest("Query " + this.process.getId() + " loaded");
 	}
 
 	/**

--- a/IRCT-API/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/controller/ResultController.java
+++ b/IRCT-API/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/controller/ResultController.java
@@ -138,7 +138,7 @@ public class ResultController {
 	public ResultDataStream getResultDataStream(User user, Long resultId,
 			String format) {
 		
-		logger.log(Level.FINE, "getResultDataStream() user:"+user.getName()+" resultId:"+resultId+" format:"+(format==null?"NULL":format));
+		logger.log(Level.FINEST, "getResultDataStream() user:"+user.getName()+" resultId:"+resultId+" format:"+(format==null?"NULL":format));
 		ResultDataStream rds = new ResultDataStream();
 		List<Result> results = getResults(user, resultId);
 
@@ -147,11 +147,11 @@ public class ResultController {
 					" and resultId: " + resultId);
 			return rds;
 		} else {
-			logger.log(Level.FINE, "getResultDataStream() there are ```"+results.size()+"``` results found.");
+			logger.log(Level.FINEST, "getResultDataStream() there are ```"+results.size()+"``` results found.");
 		}
 		Result result = results.get(0);
 		
-		logger.log(Level.FINE, "getResultDataStream() The first result status is "+result.getResultStatus().name());
+		logger.log(Level.FINEST, "getResultDataStream() The first result status is "+result.getResultStatus().name());
 		if(result.getResultStatus() != ResultStatus.AVAILABLE) {
 			rds.setMessage("Result is not available");
 			return rds;
@@ -160,7 +160,7 @@ public class ResultController {
 		ResultDataConverter rdc = irctApp.getResultDataConverter(
 				result.getDataType(), format);
 		
-		logger.log(Level.FINE, "getResultDataStream() ResultDataConverter has been retrieved");
+		logger.log(Level.FINEST, "getResultDataStream() ResultDataConverter has been retrieved");
 		if (rdc == null) {
 			rds.setMessage("Unable to find format");
 			return rds;
@@ -232,7 +232,7 @@ public class ResultController {
 	 */
 	public Result createResult(ResultDataType resultDataType)
 			throws PersistableException {
-		logger.log(Level.FINE, "createResult() "+resultDataType.toString());
+		logger.log(Level.FINEST, "createResult() "+resultDataType.toString());
 		
 		Result result = new Result();
 		entityManager.persist(result);
@@ -242,7 +242,7 @@ public class ResultController {
 
 	public Result updateResult(ResultDataType resultDataType, Result result)
 			throws PersistableException {
-		logger.log(Level.FINE, "createResult() "+resultDataType.toString());
+		logger.log(Level.FINEST, "createResult() "+resultDataType.toString());
 
 		result.setDataType(resultDataType);
 		result.setStartTime(new Date());

--- a/IRCT-RI/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/ri/i2b2transmart/I2B2TranSMARTResourceImplementation.java
+++ b/IRCT-RI/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/ri/i2b2transmart/I2B2TranSMARTResourceImplementation.java
@@ -85,7 +85,7 @@ public class I2B2TranSMARTResourceImplementation extends
 			throws ResourceInterfaceException {
 		List<Entity> returns = super.getPathRelationship(path, relationship, user);
 
-		java.util.logging.Logger.getGlobal().log(java.util.logging.Level.FINE, "getPathRelationship() ");
+		java.util.logging.Logger.getGlobal().log(java.util.logging.Level.FINEST, "getPathRelationship() ");
 		// Get the counts from the tranSMART server
 		try {
 			HttpClient client = createClient(user);
@@ -101,7 +101,7 @@ public class I2B2TranSMARTResourceImplementation extends
 				basePath = pathComponents[0] + "/" + pathComponents[1] + "/"
 						+ pathComponents[2];
 
-				java.util.logging.Logger.getGlobal().log(java.util.logging.Level.FINE, "getPathRelationship() URL:"+this.transmartURL
+				java.util.logging.Logger.getGlobal().log(java.util.logging.Level.FINEST, "getPathRelationship() URL:"+this.transmartURL
 				+ "/chart/childConceptPatientCounts");
 				HttpPost post = new HttpPost(this.transmartURL
 						+ "/chart/childConceptPatientCounts");
@@ -113,14 +113,14 @@ public class I2B2TranSMARTResourceImplementation extends
 				formParameters.add(new BasicNameValuePair("concept_level", ""));
 
 				post.setEntity(new UrlEncodedFormEntity(formParameters));
-				java.util.logging.Logger.getGlobal().log(java.util.logging.Level.FINE, "getPathRelationship() making call over HTTP");
+				java.util.logging.Logger.getGlobal().log(java.util.logging.Level.FINEST, "getPathRelationship() making call over HTTP");
 				HttpResponse response = client.execute(post);
 
 				JsonReader jsonReader = Json.createReader(response.getEntity()
 						.getContent());
 				JsonObject responseContent = jsonReader.readObject();
 
-				java.util.logging.Logger.getGlobal().log(java.util.logging.Level.FINE, "getPathRelationship() ResponseEntity:"
+				java.util.logging.Logger.getGlobal().log(java.util.logging.Level.FINEST, "getPathRelationship() ResponseEntity:"
 						+responseContent.toString());
 
 				JsonObject counts = responseContent.getJsonObject("counts");


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. The assumption is that methods that are worked on more and more recently by developers should have higher log levels (e.g., INFO as compared to FINEST). Our end goal is to reduce information overload, as well as alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and element, such as developer edits the element. In this project, we compute the DOI using the project's git history.

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can **comment on each of the transformations** in the case that this PR is not accepted. Of course, we would also love to contribute to your project.

## Transformed Logging Statements

Here is a list of DOI values for enclosing methods of transformed log invocations in your projects:


log   expression | original log level | transformed log level | enclosing method | DOI value
-- | -- | -- | -- | --
logger.log(Level.FINE,"getResultDataStream()   ResultDataConverter has been retrieved") | FINE | FINEST | getResultDataStream(edu.harvard.hms.dbmi.bd2k.irct.model.security.User,java.lang.Long,java.lang.String) | 0
logger.log(Level.FINE,"getResultDataStream()   there are ```" + results.size() + "``` results found.") | FINE | FINEST | getResultDataStream(edu.harvard.hms.dbmi.bd2k.irct.model.security.User,java.lang.Long,java.lang.String) | 0
logger.log(Level.FINE,"createResult()   " + resultDataType.toString()) | FINE | FINEST | updateResult(edu.harvard.hms.dbmi.bd2k.irct.model.result.ResultDataType,edu.harvard.hms.dbmi.bd2k.irct.model.result.Result) | 0.496
log.info("Process " +   this.process.getId() + " saved") | INFO | FINEST | saveProcess() | 0
logger.log(Level.FINE,"createResult()   " + resultDataType.toString()) | FINE | FINEST | createResult(edu.harvard.hms.dbmi.bd2k.irct.model.result.ResultDataType) | 1.862
log.info("Query " +   this.process.getId() + " loaded") | INFO | FINEST | loadProcess(java.lang.Long) | 0
logger.log(Level.FINE,"getResultDataStream()   user:" + user.getName() + " resultId:"+ resultId+ "   format:"+ (format == null ? "NULL" : format)) | FINE | FINEST | getResultDataStream(edu.harvard.hms.dbmi.bd2k.irct.model.security.User,java.lang.Long,java.lang.String) | 0
logger.log(Level.FINE,"getResultDataStream()   The first result status is " + result.getResultStatus().name()) | FINE | FINEST | getResultDataStream(edu.harvard.hms.dbmi.bd2k.irct.model.security.User,java.lang.Long,java.lang.String) | 0
java.util.logging.Logger.getGlobal().log(java.util.logging.Level.FINE,"getPathRelationship()   ") | FINE | FINEST | getPathRelationship(edu.harvard.hms.dbmi.bd2k.irct.model.ontology.Entity,edu.harvard.hms.dbmi.bd2k.irct.model.ontology.OntologyRelationship,edu.harvard.hms.dbmi.bd2k.irct.model.security.User) | 0
java.util.logging.Logger.getGlobal().log(java.util.logging.Level.FINE,"getPathRelationship()   URL:" + this.transmartURL +   "/chart/childConceptPatientCounts") | FINE | FINEST | getPathRelationship(edu.harvard.hms.dbmi.bd2k.irct.model.ontology.Entity,edu.harvard.hms.dbmi.bd2k.irct.model.ontology.OntologyRelationship,edu.harvard.hms.dbmi.bd2k.irct.model.security.User) | 0
java.util.logging.Logger.getGlobal().log(java.util.logging.Level.FINE,"getPathRelationship()   making call over HTTP") | FINE | FINEST | getPathRelationship(edu.harvard.hms.dbmi.bd2k.irct.model.ontology.Entity,edu.harvard.hms.dbmi.bd2k.irct.model.ontology.OntologyRelationship,edu.harvard.hms.dbmi.bd2k.irct.model.security.User) | 0
java.util.logging.Logger.getGlobal().log(java.util.logging.Level.FINE,"getPathRelationship()   ResponseEntity:" + responseContent.toString()) | FINE | FINEST | getPathRelationship(edu.harvard.hms.dbmi.bd2k.irct.model.ontology.Entity,edu.harvard.hms.dbmi.bd2k.irct.model.ontology.OntologyRelationship,edu.harvard.hms.dbmi.bd2k.irct.model.security.User) | 0




## Settings

We have several settings to analyze these DOI values. The settings we are using in this pull request are:
- Treat  CONFIG level as a category and not a traditional level, i.e., our tool ignores CONFIG log level (setting 0).
- Never lower the logging level of logging statements within catch blocks (setting 2).

We can vary these settings and rerun our if you desire.

## DOI Intervals

For your information, we also generate a list of DOI value intervals. Given this list, our tool could rejuvenate log levels by knowing which intervals the DOI values of enclosing methods for log invocations are in:

subject | DOI boundary | log level
-- | -- | --
i2b2-Java-API | [0.0, 0.40716663) | FINEST
i2b2-Java-API | [0.40716663, 0.81433326) | FINER
i2b2-Java-API | [0.81433326, 1.2214999) | FINE
i2b2-Java-API | [1.2214999, 1.6286665) | INFO
i2b2-Java-API | [1.6286665, 2.0358331) | WARNING
i2b2-Java-API | [2.0358331, 2.4429998) | SEVERE
IRCT-API | [0.0, 2.555) | FINEST
IRCT-API | [2.555, 5.11) | FINER
IRCT-API | [5.11, 7.665) | FINE
IRCT-API | [7.665, 10.22) | INFO
IRCT-API | [10.22, 12.775001) | WARNING
IRCT-API | [12.775001, 15.33) | SEVERE
IRCT-CL | [0.0, 2.4574995) | FINEST
IRCT-CL | [2.4574995, 4.914999) | FINER
IRCT-CL | [4.914999, 7.3724985) | FINE
IRCT-CL | [7.3724985, 9.829998) | INFO
IRCT-CL | [9.829998, 12.2874975) | WARNING
IRCT-CL | [12.2874975, 14.744997) | SEVERE
IRCT-RI | [0.0, 6.9524994) | FINEST
IRCT-RI | [6.9524994, 13.904999) | FINER
IRCT-RI | [13.904999, 20.857498) | FINE
IRCT-RI | [20.857498, 27.809998) | INFO
IRCT-RI | [27.809998, 34.762497) | WARNING
IRCT-RI | [34.762497, 41.714996) | SEVERE



