### PR TITLE
Rejuvenate log levels

### DIFF
--- a/IRCT-API/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/controller/ProcessController.java
+++ b/IRCT-API/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/controller/ProcessController.java
@@ -57,7 +57,7 @@ public class ProcessController implements Serializable{
 		} else {
 			entityManager.merge(this.process);
 		}
-		log.info("Process " + this.process.getId() + " saved");
+		log.finest("Process " + this.process.getId() + " saved");
 
 	}
 
@@ -76,7 +76,7 @@ public class ProcessController implements Serializable{
 		if (this.process == null) {
 			throw new ProcessException("No process to load.");
 		}
-		log.info("Query " + this.process.getId() + " loaded");
+		log.finest("Query " + this.process.getId() + " loaded");
 	}
 
 	/**

--- a/IRCT-RI/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/ri/i2b2transmart/I2B2TranSMARTResourceImplementation.java
+++ b/IRCT-RI/src/main/java/edu/harvard/hms/dbmi/bd2k/irct/ri/i2b2transmart/I2B2TranSMARTResourceImplementation.java
@@ -85,7 +85,7 @@ public class I2B2TranSMARTResourceImplementation extends
 			throws ResourceInterfaceException {
 		List<Entity> returns = super.getPathRelationship(path, relationship, user);
 
-		java.util.logging.Logger.getGlobal().log(java.util.logging.Level.FINE, "getPathRelationship() ");
+		java.util.logging.Logger.getGlobal().log(java.util.logging.Level.FINEST, "getPathRelationship() ");
 		// Get the counts from the tranSMART server
 		try {
 			HttpClient client = createClient(user);
@@ -101,7 +101,7 @@ public class I2B2TranSMARTResourceImplementation extends
 				basePath = pathComponents[0] + "/" + pathComponents[1] + "/"
 						+ pathComponents[2];
 
-				java.util.logging.Logger.getGlobal().log(java.util.logging.Level.FINE, "getPathRelationship() URL:"+this.transmartURL
+				java.util.logging.Logger.getGlobal().log(java.util.logging.Level.FINEST, "getPathRelationship() URL:"+this.transmartURL
 				+ "/chart/childConceptPatientCounts");
 				HttpPost post = new HttpPost(this.transmartURL
 						+ "/chart/childConceptPatientCounts");
@@ -113,14 +113,14 @@ public class I2B2TranSMARTResourceImplementation extends
 				formParameters.add(new BasicNameValuePair("concept_level", ""));
 
 				post.setEntity(new UrlEncodedFormEntity(formParameters));
-				java.util.logging.Logger.getGlobal().log(java.util.logging.Level.FINE, "getPathRelationship() making call over HTTP");
+				java.util.logging.Logger.getGlobal().log(java.util.logging.Level.FINEST, "getPathRelationship() making call over HTTP");
 				HttpResponse response = client.execute(post);
 
 				JsonReader jsonReader = Json.createReader(response.getEntity()
 						.getContent());
 				JsonObject responseContent = jsonReader.readObject();
 
-				java.util.logging.Logger.getGlobal().log(java.util.logging.Level.FINE, "getPathRelationship() ResponseEntity:"
+				java.util.logging.Logger.getGlobal().log(java.util.logging.Level.FINEST, "getPathRelationship() ResponseEntity:"
 						+responseContent.toString());
 
 				JsonObject counts = responseContent.getJsonObject("counts");


### PR DESCRIPTION
Here's a reissue of https://github.com/hms-dbmi/IRCT/pull/83 with a new version of our tool. The tool made many fewer transformations. Again, we'd appreciate any feedback and are willing to make further changes if you wish to incorporate our PR into your project.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

Treat CONFIG levels as a category and not a traditional level, i.e., our tool ignores these log levels.
Never lower the logging level of logging statements within catch blocks.
Never lower the logging level of logging statements within if statements.
Never lower the logging level of logging statements containing certain (important) keywords.
Never raise the logging level of logging statements without particular keywords in their messages.
Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
The greatest number of commits from HEAD evaluated: 1000.
The head at the time of analysis was: d67f539199b9bdd32ca30f2e4721a3a04b5c8a16